### PR TITLE
make the promQL grammar more subversive

### DIFF
--- a/src/promql-light-grammar.ts
+++ b/src/promql-light-grammar.ts
@@ -28,6 +28,7 @@ export const PromQLLightGrammar = {
     "ArithmeticBinaryOperator": "operator",
     "ComparisonBinaryOperator": "operator",
     "LogicalBinaryOperator": "operator",
+    "BoolOperator": "operator",
     "AggregationVectorMatching": "operator",
     "VectorOneToOneMatching": "operator",
     "VectorOneToManyMatching": "operator",
@@ -318,16 +319,22 @@ export const PromQLLightGrammar = {
         "vector"
       ],
       "combine": ''
+    },
+    "BoolOperator": {
+      "autocomplete": true,
+      "tokens": [
+        "bool"
+      ],
+      "combine": ''
     }
   },
 // Syntax model
   "Syntax": {
-    "BinaryOperator": "ArithmeticBinaryOperator | ComparisonBinaryOperator | LogicalBinaryOperator",
     "LabelKeyStringList": "LabelKeyString (, LabelKeyString)*",
     "LabelExpr": "LabelKeyString LabelMatchingOperator ( LabelValueString | Number )",
     // Low level vector definition
-    "SimpleInstantVector": "MetricName ('{' LabelExpr (',' LabelExpr)* '}')? | '{' LabelExpr (',' LabelExpr)* '}'",
-    "SimpleRangeVector": "SimpleInstantVector '[' Duration ']'",
+    "SimpleInstantVector": "MetricName ('{' (LabelExpr (',' LabelExpr)*)? '}')? | '{' LabelExpr (',' LabelExpr)* '}'",
+    "RangeVector": "SimpleInstantVector '[' Duration ']'",
     // Aggregation definition
     "AggregationOp": "Aggregation ('(' InstantVector ')' ( AggregationVectorMatching '(' LabelKeyStringList ')' )? | ( AggregationVectorMatching '(' LabelKeyStringList ')' )? '(' InstantVector ')')",
     "AggregationOpWithParam": "AggregationWithParameter ('(' Number ',' InstantVector ')' ( AggregationVectorMatching '(' LabelKeyStringList ')' )? | ( AggregationVectorMatching '(' LabelKeyStringList ')' )? '('  Number ',' InstantVector ')')",
@@ -344,7 +351,8 @@ export const PromQLLightGrammar = {
     "FunctionRoundOp": "FunctionRound '(' InstantVector (',' Scalar)? ')'",
     "FunctionVectorOp": "FunctionVector '(' Scalar ')'",
     "InstantVectorFunction": "FunctionTakesInstantVectorReturnsInstantVectorOp | FunctionTakesRangeVectorReturnsInstantVectorOp | FunctionClampOp | FunctionHistogramQuantileOp | FunctionHoltWintersOp | FunctionPredictLinearOp | FunctionLabelJoinOp | FunctionLabelReplaceOp | FunctionRoundOp | FunctionVectorOp",
-    // Scalar
+
+    // Scalar definition
     "FunctionDayOp": "FunctionDay '(' InstantVector? ')'",
     "FunctionScalarOp": "FunctionScalar '(' InstantVector ')'",
     "FunctionTimeOp": "FunctionTime '()'",
@@ -352,12 +360,12 @@ export const PromQLLightGrammar = {
     // Note: don't change the order, FunctionTimestampOp must be evaluated before FunctionTimeOp
     "Scalar": "Number | FunctionDayOp | FunctionScalarOp | FunctionTimestampOp | FunctionTimeOp",
     // Vector definition
-    "InstantVector": "(Scalar (ArithmeticBinaryOperator | ComparisonBinaryOperator))* (AggregationOp | AggregationOpWithParam | AggregationOverTimeOp | InstantVectorFunction | SimpleInstantVector) ((ArithmeticBinaryOperator | ComparisonBinaryOperator) Scalar)*",
-    "RangeVector": "SimpleRangeVector",
-    "Vector": "RangeVector | InstantVector",
-    "VectorMatchingOp": "Vector BinaryOperator ( VectorOneToOneMatching '(' LabelKeyStringList ')')?  ( VectorOneToManyMatching )? Vector",
+    "InstantVector": "AggregationOp | AggregationOpWithParam | AggregationOverTimeOp | InstantVectorFunction | (SimpleInstantVector ('[' Duration ']')?)",
+    // Expression definition
+    "BinOp": "( Scalar | InstantVector ) ((ArithmeticBinaryOperator | ComparisonBinaryOperator BoolOperator? | LogicalBinaryOperator ) ( VectorOneToOneMatching '(' LabelKeyStringList ')')?  VectorOneToManyMatching? Expr)?",
     // Definitive PromQL Grammar
-    "PromQLExpr": "Comment | VectorMatchingOp | Vector | Scalar"
+    "Expr": "'(' Expr ')' | BinOp",
+    "PromQLExpr": "Comment | Expr"
   },
   "Parser": [ [ "PromQLExpr" ] ]
 };


### PR DESCRIPTION
It's far better now. Now all correct syntax are covered. But unfortunately some wrong cases are not covered such as:

```bash
100 > 100 --> doesn't return an error. I did it on purpose and not sure it will be easy to make it better
100>my_tric --> it's not parsed. The parseur is waiting a space to analyze it
100 > group_left 15 ---> doesn't return an error. Same problem as 100 > 100. Grammar too subversive
1 - 100 ) --> doesn't return an error. A bit weird, no idea why
```

This PR should improve a lot the issue #1. And I think it's fair to close it.
// close #1 